### PR TITLE
Remove preferredLanguage and timestampsToCombine defaults from get-youtube-transcript tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,10 @@ server.tool(
     timestampsToCombine: z
       .number()
       .optional()
-      .default(5)
       .describe("Number of timestamps to combine"),
     preferredLanguage: z
       .string()
       .optional()
-      .default("en")
       .describe("Preferred language code"),
   },
   async ({


### PR DESCRIPTION
This PR removes the default values for `preferredLanguage` and `timestampsToCombine` parameters from the server.tool "get-youtube-transcript" as requested in issue #8.

Changes made:
- Removed `.default("en")` from the `preferredLanguage` parameter
- Removed `.default(5)` from the `timestampsToCombine` parameter

These parameters are now truly optional without default values, allowing the API to determine appropriate defaults instead.

Fixes #8

@yang-dumplingai can click here to [continue refining the PR](https://app.all-hands.dev/conversations/aa972463d02d4bd6bb3b0b7a1113f100)